### PR TITLE
Fix non-adherence to normalisation standard.

### DIFF
--- a/decrypt.go
+++ b/decrypt.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 Weald Technology Trading
+// Copyright © 2019-2021 Weald Technology Trading
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -51,6 +51,24 @@ func (e *Encryptor) Decrypt(data map[string]interface{}, passphrase string) ([]b
 	}
 
 	normedPassphrase := []byte(normPassphrase(passphrase))
+	res, err := decryptNorm(ks, normedPassphrase)
+	if err != nil {
+		// There is an alternate method to generate a normalised
+		// passphrase that can produce different results.  To allow
+		// decryption of data that may have been encrypted with the
+		// alternate method we attempt to decrypt using that method
+		// given the failure of the standard normalised method.
+		normedPassphrase = []byte(altNormPassphrase(passphrase))
+		res, err = decryptNorm(ks, normedPassphrase)
+		if err != nil {
+			// No luck either way.
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func decryptNorm(ks *keystoreV4, normedPassphrase []byte) ([]byte, error) {
 	// Decryption key
 	var decryptionKey []byte
 	if ks.KDF == nil {

--- a/decrypt_test.go
+++ b/decrypt_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 Weald Technology Trading
+// Copyright © 2019-2021 Weald Technology Trading
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -107,6 +107,18 @@ func TestDecrypt(t *testing.T) {
 			input:      `{"checksum":{"function":"sha256","message":"9ca5a58a8a8d7a62c3bd890c51ab3169bcfd7f154947458ac4f2950b059b6b38","params":{}},"cipher":{"function":"aes-128-ctr","message":"12edd28c7290896ea24ecda9066f34a70dbab972d8d975f5727f938ba5a8641f","params":{"iv":"b29d49568661b61e92352e3bb36038d9"}},"kdf":{"function":"pbkdf2","message":"","params":{"c":262144,"dklen":32,"prf":"hmac-sha256","salt":"d90262ceea3018400076177f5bc55b6e185d5e63361bebdda4a2f7a2066caadc"}}}`,
 			passphrase: "testpassword",
 			output:     []byte{0x11, 0xdd, 0xc, 0x87, 0xfe, 0xf7, 0x48, 0xdc, 0x7, 0xee, 0xb7, 0xe, 0xd, 0xe5, 0xdc, 0x94, 0x4c, 0xd4, 0xd5, 0xbe, 0x86, 0x4e, 0xc, 0x40, 0x35, 0x26, 0xf2, 0xfd, 0x34, 0x61, 0xa8, 0x3e},
+		},
+		{
+			name:       "GoodNorm",
+			input:      `{"checksum":{"function":"sha256","message":"3e1d45e3e47bcb2406ab25b6119225c85e7b2276b0834c7203a125bd7b6ca34f","params":{}},"cipher":{"function":"aes-128-ctr","message":"0ed64a392274f7fcc76f8cf4d22f86057c42e6c6b726cc19dc64e80ebab5d1dd","params":{"iv":"ff6cc499ff4bbfca0125700b29cfa4dc"}},"kdf":{"function":"pbkdf2","message":"","params":{"c":262144,"dklen":32,"prf":"hmac-sha256","salt":"70f3ebd9776781f46c2ead400a3a9ed7ad2880871fe9422a734303d1492f2477"}}}`,
+			passphrase: "testpasswordü",
+			output:     []byte{0x3f, 0xa3, 0xc2, 0xa1, 0xc9, 0xf5, 0xe6, 0xb3, 0x5b, 0x22, 0x3b, 0x8e, 0x84, 0xcc, 0xb3, 0x94, 0x83, 0x77, 0x20, 0xa7, 0x12, 0xbb, 0xd1, 0xdc, 0xdd, 0xcf, 0xeb, 0x78, 0xa2, 0x98, 0xd0, 0x63},
+		},
+		{
+			name:       "GoodAltNorm",
+			input:      `{"checksum":{"function":"sha256","message":"5bbf87c004da9b7f39f9374725c1ae89e15a52306a4d0a73654769ecb39341ed","params":{}},"cipher":{"function":"aes-128-ctr","message":"e3f3ef7027c3ddf579c7a88001ea2fcb17f850dcc8198c3f3ba0610a70a293a0","params":{"iv":"f0855894642fecdcce1696a50a2c0e4e"}},"kdf":{"function":"pbkdf2","message":"","params":{"c":262144,"dklen":32,"prf":"hmac-sha256","salt":"454932cffe9fbc0767c46280663550df4bf64205bfe9f3a359012f21dd9c30bb"}}}`,
+			passphrase: "testpasswordü",
+			output:     []byte{0x3f, 0xa3, 0xc2, 0xa1, 0xc9, 0xf5, 0xe6, 0xb3, 0x5b, 0x22, 0x3b, 0x8e, 0x84, 0xcc, 0xb3, 0x94, 0x83, 0x77, 0x20, 0xa7, 0x12, 0xbb, 0xd1, 0xdc, 0xdd, 0xcf, 0xeb, 0x78, 0xa2, 0x98, 0xd0, 0x63},
 		},
 		{
 			name: "SCrypt",

--- a/norm_internal_test.go
+++ b/norm_internal_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 Weald Technology Trading
+// Copyright © 2019-2021 Weald Technology Trading
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -41,6 +41,11 @@ func TestNormPassphrase(t *testing.T) {
 			output: "testpassword🔑",
 		},
 		{
+			name:   "Umlauts",
+			input:  "üöüöäöüöü",
+			output: "üöüöäöüöü",
+		},
+		{
 			name: "ControlCharacters",
 			input: string([]byte{
 				0x74, 0x65, 0x73, 0x74,
@@ -60,6 +65,56 @@ func TestNormPassphrase(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			assert.Equal(t, test.output, normPassphrase(test.input))
+		})
+	}
+}
+
+func TestAltNormPassphrase(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		output string
+	}{
+		{
+			name:   "Empty",
+			input:  "",
+			output: "",
+		},
+		{
+			name:   "ASCII",
+			input:  "passphrase",
+			output: "passphrase",
+		},
+		{
+			name:   "Unicode",
+			input:  "𝔱𝔢𝔰𝔱𝔭𝔞𝔰𝔰𝔴𝔬𝔯𝔡🔑",
+			output: "testpassword🔑",
+		},
+		{
+			name:   "Umlauts",
+			input:  "üöüöäöüöü",
+			output: "uouoaouou",
+		},
+		{
+			name: "ControlCharacters",
+			input: string([]byte{
+				0x74, 0x65, 0x73, 0x74,
+				0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+				0x63, 0x6f,
+				0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+				0x6e, 0x74,
+				0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+				0x72, 0x6f,
+				0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+				0x6c, 0x7f,
+			}),
+			output: "testcontrol",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.output, altNormPassphrase(test.input))
 		})
 	}
 }


### PR DESCRIPTION
The code that normalises passphrases prior to their use was not returning the expected value in some situations.  This addresses that issue, ensuring that the value returned matches the expectation.

Because pre-encrypted data will not decrypt correctly with the new mechanism the decryption function now attempts to use the old-style normalisation code if the first attempt fails.  This increases the time
to return an error if the passphrase is incorrect, but ensures that valid passphrases will decrypt the data.